### PR TITLE
Adding windows support

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -12,6 +12,8 @@
      (ffi-lib "libopenal" #:fail (λ () #f))]
     [(macosx)
      (ffi-lib "OpenAL.framework/OpenAL" #:fail (λ () #f))]
+    [(windows)
+     (ffi-lib "OpenAL32" #:fail (λ () #f))]
     [else
      #f]))
 


### PR DESCRIPTION
Adding windows support, unless it was left out intentionally.
Apologies if I missed this somewhere.

Windows openal and openal-soft dll is always called OpenAL32, even on 64 bit installs.

See https://openal-soft.org/openal-binaries/openal-soft-1.23.1-bin.zip and
https://www.openal.org/downloads/oalinst.zip